### PR TITLE
ci: update release workflow to trigger only on published releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,15 +1,8 @@
 name: Build & Push Docker Images
 
 on:
-  push:
-    branches: [main]          # build + push :latest on every merge to main
-    tags:
-      - "v*"                  # build + push versioned tag on: git tag v1.0.0 && git push --tags
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Release version (e.g. 1.0.0)"
-        required: true
+  release:
+    types: [published]
 
 jobs:
   release:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified the release workflow to trigger upon GitHub release publication instead of manual dispatch or code pushes.
  * Updated release automation to align with standard release event handling.

* **Known Issues**
  * Version resolution may fall back to `latest` tag for release events, potentially affecting image tagging accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InteraOne/InteraOne/pull/108)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->